### PR TITLE
Add support for other languages

### DIFF
--- a/Completion.py
+++ b/Completion.py
@@ -30,6 +30,33 @@ PRINT_ERROR_MESSAGE_TEMPLATE = "[Ycmd] > {} ({},{})"
 
 LOCAL_SERVER = None
 
+# A map of ycmd language specifiers to Sublime scope names
+LANG_MAP = {
+    # These languages are supported, but have names which
+    # map directly to the Sublime scope name
+    # 'c': 'c',
+    # 'objc': 'objc',
+    # 'ocaml': 'ocaml',
+    # 'c++': 'c++',
+    # 'perl': 'perl',
+    # 'php': 'php',
+    # 'cs': 'cs',
+    # 'java': 'java',
+    # 'js': 'js',
+    # 'd': 'd',
+    # 'python': 'python',
+    # 'go': 'go',
+    # 'erlang': 'erlang',
+    # 'ruby': 'ruby',
+    # 'rust': 'rust',
+    # 'lua': 'lua',
+    # 'elixir': 'elixir', # needs plugin
+    'cpp': 'c++',
+    'javascript': 'js',
+    'typescript': 'ts', # needs plugin
+    'vb': 'vbnet', # needs plugin
+    'perl6': 'perl', # Sublime doesn't treat perl 6 as different
+}
 
 def print_status(msg):
     print(msg)
@@ -98,7 +125,7 @@ def read_settings():
     settings["python_bin"] = s.get("python_binary_path", "python")
     settings["default_settings_path"] = s.get(
         "default_settings_path", os.path.join(settings["ycmd_path"], "default_settings.json"))
-    settings["languages"] = [l.replace("c++", "cpp") for l in s.get("languages", ["cpp"])]
+    settings["languages"] = s.get("languages", ["cpp"])
 
     if not settings['use_auto']:
         if not settings["hmac"] or str(settings['hmac']) == "_some_base64_key_here_==":
@@ -114,12 +141,10 @@ def read_settings():
 
 def lang(view):
     languages = read_settings()['languages']
-    if view.match_selector(view.sel()[0].begin(), 'source.c++') and 'cpp' in languages:
-        return 'cpp'
-    elif view.match_selector(view.sel()[0].begin(), 'source.rust') and 'rust' in languages:
-        return 'rust'
-    else:
-        return ''
+    for language in languages:
+        if view.match_selector(view.sel()[0].begin(), 'source.%s' % LANG_MAP.get(language, language)):
+            return language.replace('c++', 'cpp').replace('js', 'javascript')
+    return ''
 
 def get_selected_pos(view):
     try:

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,6 +8,10 @@
         "command": "ycmd_restart_server"
     },
     {
+        "caption": "Ycmd: Reload language list from settings",
+        "command": "ycmd_reload_settings"
+    },
+    {
         "caption": "Ycmd: Settings - Default",
         "command": "open_file",
         "args": { "file": "${packages}/YcmdCompletion/YcmdCompletion.sublime-settings" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 YcmdCompletion
 ==============
 
-Sublime Text 3 plugin for C++, Rust, and Python code completion and error highlighting, based on [Ycmd server](https://github.com/Valloric/ycmd)
+Sublime Text 3 plugin for code completion and error highlighting, based on [Ycmd server](https://github.com/Valloric/ycmd)
 
 ## Installation
   Simply use Package Control and Install Package `YcmdCompletion`.
@@ -20,7 +20,7 @@ Sublime Text 3 plugin for C++, Rust, and Python code completion and error highli
 
 3. Prepare `Ycmd Server` (clone to your machine and build) as it is described [here](https://github.com/Valloric/ycmd#building)
 
-Note that you need to enable Rust support explicitly with a `"languages": ["cpp", "rust", "python", "c++"],` entry in your settings file. Other languages mentioned in the default settings file may also work, however this plugin has only been tested with these three. For Rust to work ycmd needs to be compiled with racer support, see the ycmd docs for more information.
+Note that you need to enable Rust/Go support explicitly by adding them to the `languages` array in the settings file. Other languages mentioned in the default settings file may also work, however this plugin has only been tested with these. For Rust and Go to work you must have compiled ycmd with the appropriate options, check out the docs for more information. This is true for most other ycmd-supported languages as well.
 
 ###Option 1:
 4.1 Generate your personal [HMAC](https://github.com/Valloric/ycmd#is-hmac-auth-for-requestsresponses-really-necessary) key.

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Note that you need to enable Rust/Go support explicitly by adding them to the `l
 
 5.1 Run `ycmd` with your settings. You can find [this article](https://github.com/Valloric/ycmd#user-level-customization) useful. 
 
-6 Open any `*.cpp` or "*.py" file and try to use auto-completion.
+6 Open any `*.cpp` or `*.py` file and try to use auto-completion.
 
 ###Option 2:
 4.2 Go to your personal settings and set `use_auto_start_localserver` to 1
 
 5.2 Set `ycmd_path` to point to your local installation of Ycmd Server (e.g.:`home/USERNAME/ycmd/ycmd`), and either provide the location to your settings file for the ycmd Server or ignore `default_settings_path` to use the default file that comes with ycmd.
 
-6 Open any `*.cpp` or "*.py" file and try to use auto-completion.
+6 Open any `*.cpp` or `*.py` file and try to use auto-completion.
 
 ## Functions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 YcmdCompletion
 ==============
 
-Sublime Text 3 plugin for C++ code completion and error highlighting, based on [Ycmd server](https://github.com/Valloric/ycmd)
+Sublime Text 3 plugin for C++, Rust, and Python code completion and error highlighting, based on [Ycmd server](https://github.com/Valloric/ycmd)
 
 ## Installation
   Simply use Package Control and Install Package `YcmdCompletion`.
@@ -20,6 +20,8 @@ Sublime Text 3 plugin for C++ code completion and error highlighting, based on [
 
 3. Prepare `Ycmd Server` (clone to your machine and build) as it is described [here](https://github.com/Valloric/ycmd#building)
 
+Note that you need to enable Rust support explicitly with a `"languages": ["cpp", "rust", "python", "c++"],` entry in your settings file. Other languages mentioned in the default settings file may also work, however this plugin has only been tested with these three. For Rust to work ycmd needs to be compiled with racer support, see the ycmd docs for more information.
+
 ###Option 1:
 4.1 Generate your personal [HMAC](https://github.com/Valloric/ycmd#is-hmac-auth-for-requestsresponses-really-necessary) key.
   It can be done by executing additional command:
@@ -30,14 +32,14 @@ Sublime Text 3 plugin for C++ code completion and error highlighting, based on [
 
 5.1 Run `ycmd` with your settings. You can find [this article](https://github.com/Valloric/ycmd#user-level-customization) useful. 
 
-6 Open any `*.cpp` file and try to use auto-completion.
+6 Open any `*.cpp` or "*.py" file and try to use auto-completion.
 
 ###Option 2:
 4.2 Go to your personal settings and set `use_auto_start_localserver` to 1
 
 5.2 Set `ycmd_path` to point to your local installation of Ycmd Server (e.g.:`home/USERNAME/ycmd/ycmd`), and either provide the location to your settings file for the ycmd Server or ignore `default_settings_path` to use the default file that comes with ycmd.
 
-6 Open any `*.cpp` file and try to use auto-completion.
+6 Open any `*.cpp` or "*.py" file and try to use auto-completion.
 
 ## Functions
 

--- a/YcmdCompletion.sublime-settings
+++ b/YcmdCompletion.sublime-settings
@@ -49,16 +49,19 @@
 
   /*
     The languages you wish to use ycmd for.
-    Supported: cpp, rust, python
+    Supported: cpp, rust, python, go
 
     The following languages may also work, but are untested with this plugin:
     c, erlang, java, d, lua,
-    ocaml, js, perl, go, objc,
-    cpp, cs, php, ruby, rust
+    ocaml, js, perl, objc,
+    cs, php, ruby, rust
 
     These languages may also work if the corresponding Sublime
     syntax plugin is installed:
     vb, typescript, elixir
+
+    Be sure to run the "Reload language list from settings" command
+    after editing this setting
   */
   "languages": ["cpp", "python"],
 }

--- a/YcmdCompletion.sublime-settings
+++ b/YcmdCompletion.sublime-settings
@@ -49,10 +49,10 @@
 
   /*
     The languages you wish to use ycmd for.
-    Supported: cpp, rust
+    Supported: cpp, rust, python
 
     The following languages may also work, but are untested with this plugin:
-    c, erlang, java, d, lua, python,
+    c, erlang, java, d, lua,
     ocaml, js, perl, go, objc,
     cpp, cs, php, ruby, rust
 
@@ -60,5 +60,5 @@
     syntax plugin is installed:
     vb, typescript, elixir
   */
-  "languages": ["cpp"],
+  "languages": ["cpp", "python"],
 }

--- a/YcmdCompletion.sublime-settings
+++ b/YcmdCompletion.sublime-settings
@@ -46,4 +46,19 @@
     and other tools, uncomment this:
   */
   // "python_binary_path": "/usr/local/bin/python"
+
+  /*
+    The languages you wish to use ycmd for.
+    Supported: cpp, rust
+
+    The following languages may also work, but are untested with this plugin:
+    c, erlang, java, d, lua, python,
+    ocaml, js, perl, go, objc,
+    cpp, cs, php, ruby, rust
+
+    These languages may also work if the corresponding Sublime
+    syntax plugin is installed:
+    vb, typescript, elixir
+  */
+  "languages": ["cpp"],
 }

--- a/lang_map.py
+++ b/lang_map.py
@@ -23,3 +23,4 @@ LANG_MAP = {
     'vb': 'vbnet', # needs plugin
     'perl6': 'perl', # Sublime doesn't treat perl 6 as different
 }
+

--- a/lang_map.py
+++ b/lang_map.py
@@ -1,0 +1,25 @@
+# A map of ycmd language specifiers to Sublime scope names
+LANG_MAP = {
+    'c': 'c',
+    'objc': 'objc',
+    'ocaml': 'ocaml',
+    'c++': 'c++',
+    'perl': 'perl',
+    'php': 'php',
+    'cs': 'cs',
+    'java': 'java',
+    'js': 'js',
+    'd': 'd',
+    'python': 'python',
+    'go': 'go',
+    'erlang': 'erlang',
+    'ruby': 'ruby',
+    'rust': 'rust',
+    'lua': 'lua',
+    'elixir': 'elixir', # needs plugin
+    'cpp': 'c++',
+    'javascript': 'js',
+    'typescript': 'ts', # needs plugin
+    'vb': 'vbnet', # needs plugin
+    'perl6': 'perl', # Sublime doesn't treat perl 6 as different
+}

--- a/ycmd/http_client.py
+++ b/ycmd/http_client.py
@@ -187,7 +187,7 @@ def BuildRequestData(filepath='',
     return data
 
 
-def PrepareForNewFile(server, path, contents, filetype='cpp'):
+def PrepareForNewFile(server, path, contents, filetype):
     print("[Ycmd][Notify] {}".format(path))
     return server.SendEventNotification(EventEnum.FileReadyToParse,
                                         filepath=path,
@@ -195,7 +195,7 @@ def PrepareForNewFile(server, path, contents, filetype='cpp'):
                                         contents=contents)
 
 
-def CppSemanticCompletionResults(server, path, row, col, contents, filetype='cpp'):
+def SemanticCompletionResults(server, path, row, col, contents, filetype):
     print("[Ycmd][Completion] for {}:{}:{}".format(path, row, col))
     return server.SendCodeCompletionRequest(filepath=path,
                                             filetype=filetype,


### PR DESCRIPTION
Tested with Rust, works. I don't have a C++ ycmd setup so I didn't test this thoroughly with C++ (It completes `std::vector` fine, I don't know if GoTo is working), but I've only made minor changes to the C++ handling so it should be ok.

Since I haven't tested this with anything else, I've mentioned that languages other than C++ and Rust _may_ work in the prefs file.

Fixes #1

cc @LuckyGeck 
