### PR TITLE
Add user confirmation for .ycm_extra_conf loading

### DIFF
--- a/Completion.py
+++ b/Completion.py
@@ -1,6 +1,6 @@
 # -*- coding: utf8 -*-
 
-from .ycmd import http_client
+from .ycmd import http_client, exceptions
 from base64 import b64decode
 from json import loads
 from threading import Thread
@@ -168,6 +168,12 @@ def notify_func(filepath, content, callback, filetype):
     cli = get_client()
     try:
         data = http_client.PrepareForNewFile(cli, filepath, content, filetype)
+    except exceptions.UnknownExtraConf as e:
+        if sublime.ok_cancel_dialog(str(e)):
+            cli.LoadExtraConfFile(e.extra_conf_file)
+        else:
+            cli.IgnoreExtraConfFile(e.extra_conf_file)
+        return
     except Exception as e:
         print(NOTIFY_ERROR_MSG.format(e))
         return

--- a/ycmd/exceptions.py
+++ b/ycmd/exceptions.py
@@ -1,0 +1,7 @@
+# -*- coding: utf8 -*-
+
+class UnknownExtraConf(Exception):
+    def __init__(self, extra_conf_file):
+        message = "YcmdCompletion found {0}. Load?".format(extra_conf_file)
+        super(UnknownExtraConf, self).__init__(message)
+        self.extra_conf_file = extra_conf_file

--- a/ycmd/http_client.py
+++ b/ycmd/http_client.py
@@ -140,7 +140,7 @@ class YcmdClient(object):
             return readData
         except HTTPError as err:
             if err.code == 500:
-                responseAsJson = json.loads( err.read().decode('utf-8') )
+                responseAsJson = json.loads(err.read().decode('utf-8'))
                 if responseAsJson['exception']['TYPE'] == "UnknownExtraConf":
                     raise UnknownExtraConf(responseAsJson['exception']['extra_conf_file'])
             raise err


### PR DESCRIPTION
Here is an attempt at fixing https://github.com/LuckyGeck/YcmdCompletion/issues/8. The implementation is based on the discussion [here](https://github.com/abingham/emacs-ycmd/issues/19) and the implementation of .ycm_extra_conf handling in vim YCM.
